### PR TITLE
some source code polishing + suggestions for delimiter elements

### DIFF
--- a/colors/despacio.vim
+++ b/colors/despacio.vim
@@ -200,80 +200,22 @@ hi SpellRare         ctermfg=208        guifg=#ff8700       ctermbg=NONE      gu
 if 1
     " Editor Settings:
     hi Normal            ctermfg=254        guifg=#e4e4e4         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
-    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
-
-    " WindowTab Delimiters:
-    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-
-    " Language Constructs:
-    hi Comment           ctermfg=241        guifg=#626262         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-
-    " Completion Menu:
-    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi PmenuSbar         ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi PmenuThumb        ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-end
-
-"================================================================================
-" SUNSET:
-"================================================================================
-if g:despacio_Sunset
-    " Editor Settings:
-    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-
-    " WindowTab Delimiters:
-    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-
-    " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-
-    " Completion Menu:
-    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi PmenuSbar         ctermfg=234        guifg=#1c1c1c         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi PmenuThumb        ctermfg=234        guifg=#1c1c1c         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-end
-
-"================================================================================
-" TWILIGHT:
-"================================================================================
-if g:despacio_Twilight
-    " Editor Settings:
-    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=241        guifg=#626262         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -282,16 +224,16 @@ if g:despacio_Twilight
 end
 
 "================================================================================
-" MIDNIGHT:
+" SUNSET:
 "================================================================================
-if g:despacio_Midnight
+if g:despacio_Sunset
     " Editor Settings:
-    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi LineNr            ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
@@ -311,16 +253,16 @@ if g:despacio_Midnight
 end
 
 "================================================================================
-" PITCH:
+" TWILIGHT:
 "================================================================================
-if g:despacio_Pitch
+if g:despacio_Twilight
     " Editor Settings:
-    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi LineNr            ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
@@ -337,6 +279,64 @@ if g:despacio_Pitch
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi PmenuSbar         ctermfg=16         guifg=#000000         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi PmenuThumb        ctermfg=16         guifg=#000000         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+end
+
+"================================================================================
+" MIDNIGHT:
+"================================================================================
+if g:despacio_Midnight
+    " Editor Settings:
+    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+
+    " WindowTab Delimiters:
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+
+    " Language Constructs:
+    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+
+    " Completion Menu:
+    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi PmenuSbar         ctermfg=236        guifg=#303030         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi PmenuThumb        ctermfg=236        guifg=#303030         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+end
+
+"================================================================================
+" PITCH:
+"================================================================================
+if g:despacio_Pitch
+    " Editor Settings:
+    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+
+    " WindowTab Delimiters:
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+
+    " Language Constructs:
+    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+
+    " Completion Menu:
+    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi PmenuSbar         ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi PmenuThumb        ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 end
 
 if g:despacio_Clear_Skies

--- a/colors/despacio.vim
+++ b/colors/despacio.vim
@@ -33,11 +33,11 @@
 "Sunset         235      #262626      http://www.colorhexa.com/262626
 "Day            236      #303030      http://www.colorhexa.com/303030
 "Shade          237      #3a3a3a      http://www.colorhexa.com/3a3a3a
-"Ash            238      #444444      http://www.colorhexa.com/444444
 "Pebble         239      #4e4e4e      http://www.colorhexa.com/4e4e4e
 "Graphite       240      #585858      http://www.colorhexa.com/585858
 "Fog            241      #626262      http://www.colorhexa.com/626262
 "Ash            243      #767676      http://www.colorhexa.com/767676
+"Dust           244      #808080      http://www.colorhexa.com/808080
 "Stone          245      #8a8a8a      http://www.colorhexa.com/8a8a8a
 
 "Red:
@@ -200,7 +200,7 @@ hi SpellRare         ctermfg=208        guifg=#ff8700       ctermbg=NONE      gu
 if 1
     " Editor Settings:
     hi Normal            ctermfg=254        guifg=#e4e4e4         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=245        guifg=#8a8a8a         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
@@ -208,14 +208,14 @@ if 1
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=241        guifg=#626262         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=245        guifg=#8a8a8a         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=245        guifg=#8a8a8a         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=245        guifg=#8a8a8a         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=241        guifg=#626262         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=245        guifg=#8a8a8a         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -229,7 +229,7 @@ end
 if g:despacio_Sunset
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=244        guifg=#808080         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
@@ -237,14 +237,14 @@ if g:despacio_Sunset
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=244        guifg=#808080         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=244        guifg=#808080         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=244        guifg=#808080         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=244        guifg=#808080         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
@@ -258,7 +258,7 @@ end
 if g:despacio_Twilight
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=244        guifg=#808080         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -266,14 +266,14 @@ if g:despacio_Twilight
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=244        guifg=#808080         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=244        guifg=#808080         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=244        guifg=#808080         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=244        guifg=#808080         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
@@ -287,7 +287,7 @@ end
 if g:despacio_Midnight
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=244        guifg=#808080         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
@@ -295,14 +295,14 @@ if g:despacio_Midnight
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=244        guifg=#808080         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=244        guifg=#808080         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=244        guifg=#808080         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=244        guifg=#808080         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
@@ -316,7 +316,7 @@ end
 if g:despacio_Pitch
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=244        guifg=#808080         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -324,14 +324,14 @@ if g:despacio_Pitch
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=244        guifg=#808080         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=244        guifg=#808080         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=244        guifg=#808080         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=244        guifg=#808080         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
     hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE

--- a/colors/despacio.vim
+++ b/colors/despacio.vim
@@ -139,7 +139,13 @@ hi ModeMsg           ctermfg=230        guifg=#ffffdf       ctermbg=NONE      gu
 hi MoreMsg           ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Question          ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 
-" Wild Menu:
+" Number Column:
+hi Folded            ctermfg=187        guifg=#dfdfaf       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
+hi FoldColumn        ctermfg=109        guifg=#87afaf       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
+hi SignColumn        ctermfg=108        guifg=#87af87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
+
+" Completion Menu:
+hi PmenuSel          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
 hi WildMenu          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
 
 " Visual Aid:
@@ -182,9 +188,6 @@ hi DiffChange        ctermfg=234        guifg=#1c1c1c       ctermbg=137       gu
 hi DiffText          ctermfg=234        guifg=#1c1c1c       ctermbg=180       guibg=#dfaf87      cterm=NONE     gui=NONE
 hi DiffDelete        ctermfg=187        guifg=#dfdfaf       ctermbg=131       guibg=#af5f5f      cterm=NONE     gui=NONE
 
-" Completion Menu:
-hi PmenuSel          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
-
 " Spelling:
 hi SpellBad          ctermfg=167        guifg=#d75f5f       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
 hi SpellLocal        ctermfg=65         guifg=#5f875f       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
@@ -202,11 +205,6 @@ if 1
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
     hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
-
-    " Number Column:
-    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
@@ -237,11 +235,6 @@ if g:despacio_Sunset
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
     hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
-    " Number Column:
-    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
@@ -270,11 +263,6 @@ if g:despacio_Twilight
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-
-    " Number Column:
-    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -305,11 +293,6 @@ if g:despacio_Midnight
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
-    " Number Column:
-    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
@@ -338,11 +321,6 @@ if g:despacio_Pitch
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-
-    " Number Column:
-    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE

--- a/colors/despacio.vim
+++ b/colors/despacio.vim
@@ -1,11 +1,11 @@
-"   ________  _______   ________  ________  ________  ________  ___  ________     
-"  |\   ___ \|\  ___ \ |\   ____\|\   __  \|\   __  \|\   ____\|\  \|\   __  \    
-"  \ \  \_|\ \ \   __/|\ \  \___|\ \  \|\  \ \  \|\  \ \  \___|\ \  \ \  \|\  \   
-"   \ \  \ \\ \ \  \_|/_\ \_____  \ \   ____\ \   __  \ \  \    \ \  \ \  \\\  \  
-"    \ \  \_\\ \ \  \_|\ \|____|\  \ \  \___|\ \  \ \  \ \  \____\ \  \ \  \\\  \ 
+"   ________  _______   ________  ________  ________  ________  ___  ________
+"  |\   ___ \|\  ___ \ |\   ____\|\   __  \|\   __  \|\   ____\|\  \|\   __  \
+"  \ \  \_|\ \ \   __/|\ \  \___|\ \  \|\  \ \  \|\  \ \  \___|\ \  \ \  \|\  \
+"   \ \  \ \\ \ \  \_|/_\ \_____  \ \   ____\ \   __  \ \  \    \ \  \ \  \\\  \
+"    \ \  \_\\ \ \  \_|\ \|____|\  \ \  \___|\ \  \ \  \ \  \____\ \  \ \  \\\  \
 "     \ \_______\ \_______\____\_\  \ \__\    \ \__\ \__\ \_______\ \__\ \_______\
 "      \|_______|\|_______|\_________\|__|     \|__|\|__|\|_______|\|__|\|_______|
-"                         \|_________|                                            
+"                         \|_________|
 
 " A Terminal Vim colorscheme
 " Author:       Alessandro Yorba
@@ -13,7 +13,7 @@
 " License:      MIT
 
 "================================================================================
-"COLOR PALETTE:
+" COLOR PALETTE:
 "================================================================================
 
 "White:
@@ -65,7 +65,7 @@
 "Lilac          60       #5f5f87      http://www.colorhexa.com/5f5f87
 "Lake           66       #5f8787      http://www.colorhexa.com/5f8787
 "Oasis          109      #87afaf      http://www.colorhexa.com/87afaf
-"Robin          111      #87afff     http://www.colorhexa.com/87afff
+"Robin          111      #87afff      http://www.colorhexa.com/87afff
 
 "Blue:
 "================================================================================
@@ -109,7 +109,7 @@ if !exists("g:despacio_Twilight")
     let g:despacio_Twilight = 0
 endif
 
-if !exists("g:despacio_Midnight") 
+if !exists("g:despacio_Midnight")
     let g:despacio_Midnight = 0
 endif
 
@@ -126,29 +126,12 @@ if !exists("g:despacio_Campfire")
 endif
 
 "================================================================================
-" DAY:
+" COMMON SETTINGS:
 "================================================================================
 
-hi Normal           ctermfg=254        guifg=#e4e4e4       ctermbg=236       guibg=#303030       cterm=NONE     gui=NONE
-hi LineNr           ctermfg=241        guifg=#626262       ctermbg=235       guibg=#262626       cterm=NONE     gui=NONE
-hi CursorLineNR     ctermfg=187        guifg=#dfdfaf       ctermbg=235       guibg=#262626       cterm=NONE     gui=NONE
-hi CursorLine       ctermfg=NONE       guifg=NONE          ctermbg=237       guibg=#3a3a3a       cterm=NONE     gui=NONE
-
-" Number Column:
-hi Folded           ctermfg=187        guifg=#dfdfaf       ctermbg=NONE       guibg=NONE         cterm=NONE     gui=NONE
-hi FoldColumn       ctermfg=109        guifg=#87afaf       ctermbg=236        guibg=#303030      cterm=NONE     gui=NONE
-hi SignColumn       ctermfg=108        guifg=#87af87       ctermbg=236        guibg=#303030      cterm=NONE     gui=NONE
-
-" WindowTab Delimiters:
-hi TabLineFill      ctermfg=NONE        guifg=NONE          ctermbg=235       guibg=#262626      cterm=NONE     gui=NONE
-hi ColorColumn      ctermfg=NONE        guifg=NONE          ctermbg=237       guibg=#3a3a3a      cterm=NONE     gui=NONE
-hi VertSplit        ctermfg=137         guifg=#af875f       ctermbg=235       guibg=#262626      cterm=NONE     gui=NONE
-hi TabLine          ctermfg=241         guifg=#626262       ctermbg=235       guibg=#262626      cterm=NONE     gui=NONE
-hi TabLineSel       ctermfg=187         guifg=#dfdfaf       ctermbg=235       guibg=#262626      cterm=NONE     gui=NONE
-
 " File Navigation:
-hi Directory        ctermfg=216         guifg=#ffaf87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
-hi Search           ctermfg=130         guifg=#af5f00       ctermbg=187       guibg=#dfdfaf      cterm=NONE     gui=NONE
+hi Directory         ctermfg=216        guifg=#ffaf87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
+hi Search            ctermfg=130        guifg=#af5f00       ctermbg=187       guibg=#dfdfaf      cterm=NONE     gui=NONE
 
 " Prompt Status:
 hi Title             ctermfg=209        guifg=#ff875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
@@ -156,8 +139,9 @@ hi ModeMsg           ctermfg=230        guifg=#ffffdf       ctermbg=NONE      gu
 hi MoreMsg           ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Question          ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi StatusLine        ctermfg=230        guifg=#ffffdf       ctermbg=137       guibg=#af875f      cterm=NONE     gui=NONE
-hi StatusLineNC      ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE      cterm=underline gui=underline
+hi StatusLineNC      ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=underline gui=underline
 
+" Wild Menu:
 hi WildMenu          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
 
 " Visual Aid:
@@ -167,9 +151,9 @@ hi Underlined        ctermfg=66         guifg=#5f8787       ctermbg=NONE      gu
 hi WarningMsg        ctermfg=209        guifg=#ff875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi MatchParen        ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
 hi Visual            ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
-hi Todo              ctermfg=209        guifg=#ff875f       ctermbg=236       guibg=#303030      cterm=reverse  gui=reverse
+hi Todo              ctermfg=209        guifg=#ff875f       ctermbg=NONE      guibg=NONE         cterm=reverse  gui=reverse
 hi Error             ctermfg=167        guifg=#d75f5f       ctermbg=233       guibg=#121212      cterm=reverse  gui=reverse
-hi ErrorMsg          ctermfg=167        guifg=#d75f5f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE 
+hi ErrorMsg          ctermfg=167        guifg=#d75f5f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 
 " Variable Types:
 hi Constant          ctermfg=166        guifg=#d75f00       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
@@ -182,7 +166,6 @@ hi StorageClass      ctermfg=180        guifg=#dfaf87       ctermbg=NONE      gu
 hi Label             ctermfg=180        guifg=#dfaf87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Statement         ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Operator          ctermfg=180        guifg=#dfaf87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
-hi Comment           ctermfg=241        guifg=#626262       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Special           ctermfg=216        guifg=#ffaf87       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 
 " C Like:
@@ -190,28 +173,57 @@ hi PreProc           ctermfg=209        guifg=#ff875f       ctermbg=NONE      gu
 hi Type              ctermfg=223        guifg=#ffdfaf       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 
 " HTML:
-hi htmlStatement     ctermfg=223        guifg=#ffdfaf        ctermbg=NONE     guibg=NONE         cterm=NONE     gui=NONE
+hi htmlStatement     ctermfg=223        guifg=#ffdfaf       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi htmlItalic        ctermfg=209        guifg=#ff875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
-hi htmlArg           ctermfg=166        guifg=#d75f00        ctermbg=NONE     guibg=NONE         cterm=NONE     gui=NONE
+hi htmlArg           ctermfg=166        guifg=#d75f00       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 
 "FIXME:
 " Diff:
-hi DiffAdd           ctermfg=234        guifg=#1c1c1c        ctermbg=223      guibg=#ffdfaf      cterm=NONE     gui=NONE
-hi DiffChange        ctermfg=234        guifg=#1c1c1c        ctermbg=137      guibg=#af875f      cterm=NONE     gui=NONE
-hi DiffText          ctermfg=234        guifg=#1c1c1c        ctermbg=180      guibg=#dfaf87      cterm=NONE     gui=NONE
-hi DiffDelete        ctermfg=187        guifg=#dfdfaf        ctermbg=131      guibg=#af5f5f      cterm=NONE     gui=NONE
+hi DiffAdd           ctermfg=234        guifg=#1c1c1c       ctermbg=223       guibg=#ffdfaf      cterm=NONE     gui=NONE
+hi DiffChange        ctermfg=234        guifg=#1c1c1c       ctermbg=137       guibg=#af875f      cterm=NONE     gui=NONE
+hi DiffText          ctermfg=234        guifg=#1c1c1c       ctermbg=180       guibg=#dfaf87      cterm=NONE     gui=NONE
+hi DiffDelete        ctermfg=187        guifg=#dfdfaf       ctermbg=131       guibg=#af5f5f      cterm=NONE     gui=NONE
 
 " Completion Menu:
-hi Pmenu             ctermfg=187        guifg=#dfdfaf        ctermbg=235      guibg=#262626      cterm=NONE     gui=NONE
-hi PmenuSel          ctermfg=230        guifg=#ffffdf        ctermbg=66       guibg=#5f8787      cterm=NONE     gui=NONE
-hi PmenuSbar         ctermfg=235        guifg=#262626        ctermbg=235      guibg=#262626      cterm=NONE     gui=NONE
-hi PmenuThumb        ctermfg=235        guifg=#262626        ctermbg=235      guibg=#262626      cterm=NONE     gui=NONE
+hi PmenuSel          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
 
 " Spelling:
-hi SpellBad          ctermfg=167        guifg=#d75f5f        ctermbg=NONE     guibg=NONE         cterm=undercurl gui=undercurl
-hi SpellLocal        ctermfg=65         guifg=#5f875f        ctermbg=NONE     guibg=NONE         cterm=undercurl gui=undercurl
-hi SpellCap          ctermfg=111        guifg=#87afff        ctermbg=NONE     guibg=NONE         cterm=undercurl gui=undercurl
-hi SpellRare         ctermfg=208        guifg=#ff8700        ctermbg=NONE     guibg=NONE         cterm=undercurl gui=undercurl
+hi SpellBad          ctermfg=167        guifg=#d75f5f       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
+hi SpellLocal        ctermfg=65         guifg=#5f875f       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
+hi SpellCap          ctermfg=111        guifg=#87afff       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
+hi SpellRare         ctermfg=208        guifg=#ff8700       ctermbg=NONE      guibg=NONE         cterm=undercurl gui=undercurl
+
+"================================================================================
+" DAY:
+"================================================================================
+if 1
+    " Editor Settings:
+    hi Normal            ctermfg=254        guifg=#e4e4e4         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=237      guibg=#3a3a3a      cterm=NONE    gui=NONE
+
+    " Number Column:
+    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+
+    " WindowTab Delimiters:
+    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+
+    " Language Constructs:
+    hi Comment           ctermfg=241        guifg=#626262         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+
+    " Completion Menu:
+    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi PmenuSbar         ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi PmenuThumb        ctermfg=235        guifg=#262626         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+end
 
 "================================================================================
 " SUNSET:
@@ -220,23 +232,21 @@ if g:despacio_Sunset
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi LineNr            ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
-    hi CursorLineNR      ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
     " Number Column:
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
     hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-
-    "Visual Aid:
-    hi Todo              ctermfg=209        guifg=#ff875f         ctermbg=235      guibg=#262626      cterm=reverse  gui=reverse
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
     " Language Constructs:
     hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
@@ -254,25 +264,22 @@ if g:despacio_Twilight
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi LineNr            ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi CursorLineNR      ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 
     " Number Column:
-    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
     hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
     hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=233      guibg=#262626      cterm=NONE    gui=NONE
-    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
-    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
-    "Visual Aid:
-    hi Todo              ctermfg=209        guifg=#ff875f         ctermbg=234      guibg=#1c1c1c      cterm=reverse  gui=reverse
-    
     " Language Constructs:
     hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
@@ -289,31 +296,29 @@ if g:despacio_Midnight
     " Editor Settings:
     hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi LineNr            ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi CursorLineNR      ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
     " Number Column:
-    hi SignColumn       ctermfg=108         guifg=#87af87         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi Folded           ctermfg=187         guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn       ctermfg=109         guifg=#87afaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit        ctermfg=137         guifg=#af875f         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi ColorColumn      ctermfg=NONE        guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
-    hi TabLineFill      ctermfg=NONE        guifg=NONE            ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi TabLine          ctermfg=240         guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi TabLineSel       ctermfg=187         guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-
-    "Visual Aid:
-    hi Todo              ctermfg=209        guifg=#ff875f         ctermbg=233      guibg=#121212      cterm=reverse  gui=reverse
+    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment          ctermfg=240         guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
-    hi Pmenu            ctermfg=187         guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi PmenuSbar        ctermfg=232         guifg=#080808         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi PmenuThumb       ctermfg=232         guifg=#080808         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi PmenuSbar         ctermfg=232        guifg=#080808         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi PmenuThumb        ctermfg=232        guifg=#080808         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 end
 
 "================================================================================
@@ -321,38 +326,37 @@ end
 "================================================================================
 if g:despacio_Pitch
     " Editor Settings:
-    hi Normal           ctermfg=188         guifg=#dfdfdf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi LineNr           ctermfg=240         guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
-    hi CursorLine       ctermfg=NONE        guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
-    hi CursorLineNR     ctermfg=187         guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi Normal            ctermfg=188        guifg=#dfdfdf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi LineNr            ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi CursorLineNr      ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi ColorColumn       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
     " Number Column:
-    hi SignColumn       ctermfg=108         guifg=#87af87         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
-    hi Folded           ctermfg=187         guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
-    hi FoldColumn       ctermfg=109         guifg=#87afaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi Folded            ctermfg=187        guifg=#dfdfaf         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi FoldColumn        ctermfg=109        guifg=#87afaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit        ctermfg=137         guifg=#af875f         ctermbg=16       guibg=#000000      cterm=NONE     gui=NONE
-    hi ColorColumn      ctermfg=NONE        guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE     gui=NONE
-    hi TabLineFill      ctermfg=NONE        guifg=NONE            ctermbg=16       guibg=#000000      cterm=NONE     gui=NONE
-    hi TabLine          ctermfg=240         guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE     gui=NONE
-    hi TabLineSel       ctermfg=187         guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE     gui=NONE
-
-    "Visual Aid:
-    hi Todo              ctermfg=209        guifg=#ff875f         ctermbg=232      guibg=#080808      cterm=reverse  gui=reverse
+    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi TabLine           ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
 
     " Language Constructs:
-    hi Comment          ctermfg=240         guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE     gui=NONE
+    hi Comment           ctermfg=240        guifg=#585858         ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 
     " Completion Menu:
-    hi Pmenu            ctermfg=187         guifg=#dfdfaf         ctermbg=16      guibg=#000000      cterm=NONE    gui=NONE
-    hi PmenuSbar        ctermfg=16          guifg=#000000         ctermbg=16      guibg=#000000      cterm=NONE    gui=NONE
-    hi PmenuThumb       ctermfg=16          guifg=#000000         ctermbg=16      guibg=#000000      cterm=NONE    gui=NONE
+    hi Pmenu             ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi PmenuSbar         ctermfg=16         guifg=#000000         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi PmenuThumb        ctermfg=16         guifg=#000000         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
 end
 
 if g:despacio_Clear_Skies
     " Editor Settings:
-    hi CursorLine       ctermfg=NONE        guifg=NONE            ctermbg=NONE    guibg=NONE         cterm=NONE    gui=NONE
+    hi CursorLine        ctermfg=NONE       guifg=NONE            ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
+    hi CursorColumn      ctermfg=NONE       guifg=NONE            ctermbg=NONE     guibg=NONE         cterm=NONE    gui=NONE
 end
 
 "================================================================================

--- a/colors/despacio.vim
+++ b/colors/despacio.vim
@@ -138,8 +138,6 @@ hi Title             ctermfg=209        guifg=#ff875f       ctermbg=NONE      gu
 hi ModeMsg           ctermfg=230        guifg=#ffffdf       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi MoreMsg           ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
 hi Question          ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=NONE     gui=NONE
-hi StatusLine        ctermfg=230        guifg=#ffffdf       ctermbg=137       guibg=#af875f      cterm=NONE     gui=NONE
-hi StatusLineNC      ctermfg=137        guifg=#af875f       ctermbg=NONE      guibg=NONE         cterm=underline gui=underline
 
 " Wild Menu:
 hi WildMenu          ctermfg=230        guifg=#ffffdf       ctermbg=66        guibg=#5f8787      cterm=NONE     gui=NONE
@@ -211,7 +209,9 @@ if 1
     hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=236      guibg=#303030      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=241        guifg=#626262         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
@@ -243,7 +243,9 @@ if g:despacio_Sunset
     hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=235      guibg=#262626      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
@@ -275,7 +277,9 @@ if g:despacio_Twilight
     hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=234      guibg=#1c1c1c      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=233      guibg=#262626      cterm=NONE    gui=NONE
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
@@ -307,7 +311,9 @@ if g:despacio_Midnight
     hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=233      guibg=#121212      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
@@ -339,7 +345,9 @@ if g:despacio_Pitch
     hi SignColumn        ctermfg=108        guifg=#87af87         ctermbg=232      guibg=#080808      cterm=NONE    gui=NONE
 
     " WindowTab Delimiters:
-    hi VertSplit         ctermfg=137        guifg=#af875f         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi StatusLine        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi StatusLineNC      ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
+    hi VertSplit         ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi TabLine           ctermfg=240        guifg=#585858         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi TabLineSel        ctermfg=187        guifg=#dfdfaf         ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE
     hi TabLineFill       ctermfg=NONE       guifg=NONE            ctermbg=16       guibg=#000000      cterm=NONE    gui=NONE


### PR DESCRIPTION
bd38a0e and 7199023 do not change the colors
5efd59a restores the colors previously used in Despacio
7c772c2 and a16d2f6 implement the suggested grey-on-grey delimiters

TODO:
CursorLine are CursorColumn should probably be made more visible for Midnight and Pitch
ColorColumn should probably get some non-gray color and move into the general section 